### PR TITLE
feat(layout): improve language picker

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -7,3 +7,14 @@
     text-decoration: underline;
   }
 }
+
+body {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+footer {
+  margin-top: auto;
+}

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,4 +1,4 @@
 home_title = "Wie X in Y"
 translations = "Übersetzungen"
-no_translation = "Keine Übersetzung verfügbar"
+no_translation = "Keine Übersetzung"
 in_language = "in"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,5 +1,5 @@
 home_title = "How to X in Y"
-
-translations = "translations"
-no_translation = "No translation available"
+contribute = "Contribute"
+translations = "Translations"
+no_translation = "No translation"
 in_language = "in"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,10 +6,11 @@
   {{ partial "head" . }}
   <body>
     {{ partial "header" . }}
-    <main>
+    <main class="container">
       {{ block "main" . }}{{ end }}
     </main>
     {{ partial "footer" . }}
     {{ partial "assets/js" . }}
+    {{ partial "debug" . }}
   </body>
 </html>

--- a/layouts/partials/assets/css.html
+++ b/layouts/partials/assets/css.html
@@ -1,6 +1,6 @@
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.classless.zinc.min.css"
+  href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.zinc.min.css"
 />
 {{ with resources.Get "sass/main.scss" }}
   {{ $opts := dict

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,4 @@
-<footer>
+<footer class="container">
   <div>
     {{ with .File }}
       {{ $href := printf "%s/blob/main/content/%s/%s" $.Site.Params.repo $.Lang .Path }}
@@ -12,6 +12,4 @@
       </a>
     {{ end }}
   </div>
-
-  {{ partial "debug.html" . }}
 </footer>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,21 +1,25 @@
-<header>
+<header class="container">
+  <nav>
+    <div></div>
+    {{ partial "i18n/picker" . }}
+  </nav>
+
   <h1>
     {{ if not .IsHome }}
-      <a href="{{ .Site.BaseURL }}" aria-label="Home">⇧</a>&nbsp;
+      <a href="{{ .Site.BaseURL }}" aria-label="Home" data-pagefind-ignore="all"
+        >⇧</a
+      >&nbsp;
     {{ end }}
     {{ partial "title" . }}
   </h1>
-  {{ partial "i18n/picker" . }}
 
-  <div>
-    <input
-      id="search"
-      name="search"
-      type="search"
-      aria-label="search"
-      placeholder="Search"
-    />
-    <small id="search-helper"></small>
-    <ul id="results"></ul>
-  </div>
+  <input
+    id="search"
+    name="search"
+    type="search"
+    aria-label="search"
+    placeholder="Search"
+  />
+  <small id="search-helper"></small>
+  <ul id="results"></ul>
 </header>

--- a/layouts/partials/i18n/picker.html
+++ b/layouts/partials/i18n/picker.html
@@ -24,7 +24,7 @@
       </summary>
       <ul>
         <li>
-          <a href="#">contribute!</a>
+          <a href="#">{{ T "contribute" }}</a>
         </li>
       </ul>
     </details>

--- a/layouts/partials/i18n/picker.html
+++ b/layouts/partials/i18n/picker.html
@@ -2,7 +2,7 @@
   {{ with .Translations }}
     <details class="dropdown">
       <summary>
-        {{ $.Site.Language.LanguageName }}
+        {{ $.Site.Language.LanguageCode }}
       </summary>
       <ul>
         {{ range . }}
@@ -11,13 +11,22 @@
               href="{{ .RelPermalink }}"
               hreflang="{{ .Language.LanguageCode }}"
             >
-              {{ or .Language.LanguageName .Language.Lang }}</a
+              {{ .Language.LanguageCode }}</a
             >
           </li>
         {{ end }}
       </ul>
     </details>
   {{ else }}
-    {{ T "no_translation" }}
+    <details class="dropdown">
+      <summary>
+        {{ T "no_translation" }}
+      </summary>
+      <ul>
+        <li>
+          <a href="#">contribute!</a>
+        </li>
+      </ul>
+    </details>
   {{ end }}
 </div>

--- a/script/serve
+++ b/script/serve
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 
+set -e
+
+IP="$(hostname -I | cut -d' ' -f1)"
+
 hugo serve \
+    --bind 0.0.0.0 \
+    --baseURL "http://${IP}:1313/" \
+    --openBrowser \
     --cleanDestinationDir \
     --printPathWarnings \
     --printI18nWarnings \


### PR DESCRIPTION
Fix #26

The language picker was put _before_ the title as to not fail when it is too big. Also for now I've switched to using language codes, maybe full names will be better in the future.

Before:

![image](https://github.com/user-attachments/assets/cc6a8167-372c-4634-b642-4fe012b7ed3e)
![image](https://github.com/user-attachments/assets/949ca071-7cc5-4be1-91e5-58d720450552)

After:

![image](https://github.com/user-attachments/assets/03479b47-b779-4249-b001-544d8e1e39b6)
![image](https://github.com/user-attachments/assets/52c98aa9-e95f-443b-9149-ba6cd04ca386)
